### PR TITLE
Updated to 1.0.6 (fixed bugs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,60 @@
+## arteMetrics
+
+Creating performance monitors for Apollo implementations of GraphQL.
+
+```js
+const arteMetrics = require("artemetrics");
+arteMetrics.process(request);
+```
+
+## Features
+
+- GrahpQL Tracing
+- more features
+- and more...
+- moooooore
+
+## Installation
+
+arteMetrics consists of an NPM package available through the
+[npm registry](https://www.npmjs.com/) and a [react web app](https://reactjs.org/).
+
+#### Node module
+
+Install the [artemetrics](https://www.npmjs.com/package/artemetrics) node module
+
+```
+npm install artemetrics
+```
+
+test installation by running the 'process' method.
+
+```javascript
+const arteMetrics = require("artemetrics");
+arteMetrics.process(request);
+```
+
+#### React App
+
+Description of web app
+
+## Contributing
+
+arteMetrics welomes contributions in any form. If you have something you would like to add, create a pull request.
+
+## People
+
+[Sean Arseneault](https://github.com/itsmesean),
+[Brian Chiang](https://github.com/ch-brian),
+[Saejin Kang](https://github.com/skang1004),
+[Noah King](https://github.com/code-ark),
+[Joseph Renolayan](https://github.com/jodaisu),
+
+## License
+
+[MIT](LICENSE)
+
+[npm-image]: **
+[npm-url]: https://www.npmjs.com/package/artemetrics
+[downloads-image]: **
+[downloads-url]: https://npmjs.org/package/artemetrics

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Creating performance monitors for Apollo implementations of GraphQL.
 
 ```js
 const arteMetrics = require("artemetrics");
-arteMetrics.process(request);
+arteMetrics.process(response);
 ```
 
 ## Features
@@ -31,7 +31,7 @@ test installation by running the 'process' method.
 
 ```javascript
 const arteMetrics = require("artemetrics");
-arteMetrics.process(request);
+arteMetrics.process(response);
 ```
 
 #### React App

--- a/db/model.js
+++ b/db/model.js
@@ -1,3 +1,4 @@
+require("dotenv").config();
 const { Pool } = require("pg");
 const pool = new Pool({
   connectionString: process.env.PG

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const arteMetrics = {};
+const db = require("./db/model");
 
-arteMetrics.process = request => {
+arteMetrics.process = response => {
   const text =
     "INSERT INTO trace_response(fieldName, startOffset, duration) VALUES($1, $2, $3) RETURNING *";
   const values = [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "artemetrics",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "artemetrics",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8,6 +8,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
       "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw=="
+    },
+    "dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
     },
     "packet-reader": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "artemetrics",
-  "version": "1.0.1",
+  "version": "1.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artemetrics",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Creating performance monitors for Apollo implementations of GraphQL.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artemetrics",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Creating performance monitors for Apollo implementations of GraphQL.",
   "main": "index.js",
   "scripts": {
@@ -18,6 +18,7 @@
   },
   "homepage": "https://github.com/oslabs-beta/arteMetrics#readme",
   "dependencies": {
+    "dotenv": "^8.2.0",
     "pg": "^7.18.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,22 +1,22 @@
 {
   "name": "artemetrics",
-  "version": "1.0.1",
-  "description": "",
+  "version": "1.0.5",
+  "description": "Creating performance monitors for Apollo implementations of GraphQL.",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/itsmesean/arteMetrics.git"
+    "url": "git+https://github.com/oslabs-beta/arteMetrics.git"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/itsmesean/arteMetrics/issues"
+    "url": "https://github.com/oslabs-beta/arteMetrics/issues"
   },
-  "homepage": "https://github.com/itsmesean/arteMetrics#readme",
+  "homepage": "https://github.com/oslabs-beta/arteMetrics#readme",
   "dependencies": {
     "pg": "^7.18.2"
   }


### PR DESCRIPTION
fixed variable names 'request' to 'response'
required db from ./db/model